### PR TITLE
feat: 历史记录中支持解析 b 站

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { createResource, createSignal, onMount, Show } from "solid-js";
-import { LazyFlex, LazyToast } from "./lazy";
+import { LazyDialog, LazyFlex, LazyToast } from "./lazy";
 import { AppContext } from "./context";
 import { showMainWindow, getAllHistory, readConfigFile } from "./command";
 import History from "./components/history";
@@ -7,6 +7,7 @@ import Search from "./components/search";
 import Settings from "./components/settings";
 import Result from "./components/result";
 import "./App.scss";
+import BiliCookieEditor from "./components/settings/bili-cookie";
 
 const App = () => {
   const [items, { refetch: refetchHistoryItems }] =
@@ -17,6 +18,9 @@ const App = () => {
   const [parsedResult, setParsedResult] = createSignal<ParsedResult | null>(
     null,
   );
+
+  const [showBilibiliCookieEditor, setShowBilibiliCookieEditor] =
+    createSignal(false);
 
   onMount(() => {
     showMainWindow();
@@ -30,6 +34,7 @@ const App = () => {
           { toast, setToast },
           { config, refetchConfig },
           { parsedResult, setParsedResult },
+          { showBilibiliCookieEditor, setShowBilibiliCookieEditor },
         ]}
       >
         <History items={items()} />
@@ -45,6 +50,16 @@ const App = () => {
         </LazyFlex>
 
         <Settings />
+
+        <LazyDialog
+          class="bili-cookie-dialog"
+          title="输入 B 站 cookie"
+          show={showBilibiliCookieEditor()}
+          onClose={() => setShowBilibiliCookieEditor(false)}
+          maskClosable={false}
+        >
+          <BiliCookieEditor />
+        </LazyDialog>
       </AppContext.Provider>
 
       <LazyToast

--- a/src/components/history/item.tsx
+++ b/src/components/history/item.tsx
@@ -1,7 +1,7 @@
 import { AiFillApi, AiFillChrome, AiFillDelete } from "solid-icons/ai";
-import { createSignal, Show, useContext } from "solid-js";
-import { deleteHistoryByID, open, readConfigFile } from "~/command";
-import { AppContext } from "~/context";
+import { createSignal, Show } from "solid-js";
+import { deleteHistoryByID, open } from "~/command";
+import { useAppContext } from "~/context";
 import {
   LazyButton,
   LazyCol,
@@ -12,14 +12,20 @@ import {
   LazyText,
   LazyTooltip,
 } from "~/lazy";
-import { platforms } from "~/parser";
+import { parse, platforms } from "~/parser";
 
 interface HistoryItemProps extends HistoryItem {
   onDelete: () => void;
 }
 
 const HistoryItem = (props: HistoryItemProps) => {
-  const [_, { setToast }, __, { setParsedResult }] = useContext(AppContext)!;
+  const [
+    _,
+    { setToast },
+    { config },
+    { setParsedResult },
+    { setShowBilibiliCookieEditor },
+  ] = useAppContext();
 
   const [parsing, setParsing] = createSignal(false);
 
@@ -31,19 +37,14 @@ const HistoryItem = (props: HistoryItemProps) => {
   const onParse = async () => {
     setParsing(true);
 
-    if (props.platform === "bilibili") {
-      const config = await readConfigFile();
-      console.log(config);
-    } else {
-      const r = await platforms[props.platform].parser(
-        props.room_id.toString(),
-      );
-      if (r instanceof Error) {
-        setToast({ type: "error", message: r.message });
-      } else if (r) {
-        setParsedResult(r);
-      }
-    }
+    await parse(
+      props.platform,
+      props.room_id.toString(),
+      config()!,
+      setShowBilibiliCookieEditor,
+      setToast,
+      setParsedResult,
+    );
 
     setParsing(false);
   };

--- a/src/components/settings/bili-cookie.tsx
+++ b/src/components/settings/bili-cookie.tsx
@@ -1,14 +1,16 @@
-import { createSignal, useContext } from "solid-js";
+import { createSignal } from "solid-js";
 import { writeConfigFile } from "~/command";
-import { AppContext } from "~/context";
+import { useAppContext } from "~/context";
 import { LazyButton, LazyFlex, LazyTextArea } from "~/lazy";
 
-interface BiliCookieEditorProps {
-  onCancel: () => void;
-}
-
-const BiliCookieEditor = (props: BiliCookieEditorProps) => {
-  const { config, refetchConfig } = useContext(AppContext)![2];
+const BiliCookieEditor = () => {
+  const [
+    _,
+    __,
+    { config, refetchConfig },
+    ___,
+    { setShowBilibiliCookieEditor },
+  ] = useAppContext();
 
   const [cookie, setCookie] = createSignal(config()?.platform.bilibili.cookie);
 
@@ -20,7 +22,7 @@ const BiliCookieEditor = (props: BiliCookieEditorProps) => {
 
     await writeConfigFile(newConfig);
     refetchConfig();
-    props.onCancel();
+    setShowBilibiliCookieEditor(false);
   };
 
   return (
@@ -28,7 +30,7 @@ const BiliCookieEditor = (props: BiliCookieEditorProps) => {
       <LazyTextArea rows={6} value={cookie()} onInput={(s) => setCookie(s)} />
 
       <LazyFlex justify="round">
-        <LazyButton danger onClick={props.onCancel}>
+        <LazyButton danger onClick={() => setShowBilibiliCookieEditor(false)}>
           取消
         </LazyButton>
         <LazyButton

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,11 @@
-import { createContext } from "solid-js";
+import { createContext, useContext } from "solid-js";
 
 export const AppContext = createContext<AppContext>();
+
+export function useAppContext() {
+  const context = useContext(AppContext);
+  if (!context) {
+    throw new Error("useCounterContext: cannot find a AppContext");
+  }
+  return context;
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -53,3 +53,37 @@ export const handleParsingError = (error: unknown): Error => {
       return error as Error;
   }
 };
+
+export const parse = async (
+  platform: Platform,
+  input: string,
+  config: Config,
+  setShowBilibiliCookieEditor: Setter<boolean>,
+  setToast: AppContext[1]["setToast"],
+  setParsedResult: AppContext[3]["setParsedResult"],
+) => {
+  let result: ParsedResult | Error | null = null;
+
+  try {
+    if (platform === "bilibili") {
+      if (!config.platform.bilibili.cookie.length) {
+        setShowBilibiliCookieEditor(true);
+      } else {
+        result = await platforms.bilibili.parser(
+          input,
+          config.platform.bilibili.cookie,
+        );
+      }
+    } else {
+      result = await platforms[platform!].parser(input);
+    }
+  } catch (e) {
+    result = handleParsingError(e);
+  }
+
+  if (result instanceof Error) {
+    setToast({ type: "error", message: result.message });
+  } else if (result) {
+    setParsedResult(result);
+  }
+};

--- a/types/context.d.ts
+++ b/types/context.d.ts
@@ -23,4 +23,8 @@ type AppContext = [
     parsedResult: Accessor<ParsedResult | null>;
     setParsedResult: Setter<ParsedResult | null>;
   },
+  {
+    showBilibiliCookieEditor: Accessor<boolean>;
+    setShowBilibiliCookieEditor: Setter<boolean>;
+  },
 ];


### PR DESCRIPTION
- 将 B 站 cookie 设置移动到 settings 目录, 并在 App 组件中使用
- 提取公共解析函数减少重复代码
- 包装 context 函数但于处理上下文