### PR TITLE
fix(douyin): 修复获取分类失败和空链接的问题

### DIFF
--- a/src/parser/douyin/index.ts
+++ b/src/parser/douyin/index.ts
@@ -104,11 +104,14 @@ class DouyinParser extends LiveStreamParser {
       platform: "douyin",
       anchor: user.nickname,
       title: data[0].title,
-      links: [flv_pull_url.FULL_HD1, hls_pull_url_map.FULL_HD1], // NOTE: FULL_HD1 日目前已知的最高清, 不确定 2K 和 4K 的标识
+      links: [
+        flv_pull_url.FULL_HD1 ?? flv_pull_url.HD1,
+        hls_pull_url_map.FULL_HD1 ?? hls_pull_url_map.HD1,
+      ], // NOTE: FULL_HD1 日目前已知的最高清, 不确定 2K 和 4K 的标识
       roomID: this.roomID,
       category:
-        partition_road_map.sub_partition?.partition.title ??
-        partition_road_map.partition?.title ??
+        partition_road_map.sub_partition?.partition.title ||
+        partition_road_map.partition?.title ||
         "",
     };
   }


### PR DESCRIPTION
- 修正了在 FLV 和 HLS 拉取地址可能为空的情况下导致的错误，现在会使用备选的高清链接 HD1。
- 解决了分类信息获取失败时返回空字符串的问题，确保至少返回一级分类的标题。