### PR TITLE
feat: 添加获取媒体播放器路径的功能并扩展错误处理

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -37,6 +37,8 @@ pub(super) enum LsarError {
     #[error(transparent)]
     SerdeJSON(#[from] serde_json::Error),
     #[error(transparent)]
+    VarError(#[from] std::env::VarError),
+    #[error(transparent)]
     ParseInt(#[from] std::num::ParseIntError),
     #[error("{0}")]
     Other(String),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod history;
 mod http;
 mod log;
 mod parser;
+mod path;
 mod platform;
 mod setup;
 #[cfg(desktop)]
@@ -27,6 +28,7 @@ use crate::eval::eval_result;
 use crate::http::{get, post};
 use crate::log::{debug, error, info, trace, warn};
 use crate::parser::{parse_bilibili, parse_douyin, parse_douyu, parse_huya};
+use crate::path::get_player_paths;
 use crate::setup::{setup_app, setup_logging};
 use crate::utils::md5;
 
@@ -95,6 +97,7 @@ pub fn run() {
             parse_huya,
             parse_douyin,
             parse_bilibili,
+            get_player_paths
         ])
         .run(tauri::generate_context!())
         .expect("Error while running tauri application");

--- a/src-tauri/src/path.rs
+++ b/src-tauri/src/path.rs
@@ -1,0 +1,37 @@
+use std::{env, path::PathBuf};
+
+use crate::error::LsarResult;
+
+#[tauri::command]
+pub fn get_player_paths() -> LsarResult<Vec<PathBuf>> {
+    let commands = ["mpv"];
+    debug!("Searching for player commands: {:?}", commands);
+
+    let mut player_paths = Vec::new();
+
+    let paths = env::var("PATH").map_err(|e| {
+        error!("Failed to get PATH environment variable: {}", e);
+        e
+    })?;
+
+    debug!("PATH environment variable found");
+
+    for path_entry in paths.split(':') {
+        debug!("Searching in PATH entry: {}", path_entry);
+        for cmd in &commands {
+            let path = PathBuf::from(path_entry).join(cmd);
+            if path.exists() && path.is_file() {
+                info!("Found player: {}", path.display());
+                player_paths.push(path);
+            }
+        }
+    }
+
+    if player_paths.is_empty() {
+        warn!("No player paths found");
+    } else {
+        info!("Found {} player paths", player_paths.len());
+    }
+
+    Ok(player_paths)
+}


### PR DESCRIPTION
- 在 `src-tauri/src/lib.rs` 中新增了对 `path` 模块的引用。
- 实现了 `get_player_paths` 函数，该函数搜索预定义的媒体播放器命令（目前仅 mpv）在系统路径中的可执行文件。
- 将 `std::env::VarError` 添加到 `src-tauri/src/error.rs` 中的 `LsarError` 枚举，以便更好地处理环境变量相关的错误。
- 在 `src-tauri/src/path.rs` 新建文件，包含用于搜索系统路径中播放器命令的逻辑。