### PR TITLE
feat: 更新播放器路径处理并优化样式与代码

### DIFF
--- a/src-tauri/src/path.rs
+++ b/src-tauri/src/path.rs
@@ -4,7 +4,11 @@ use crate::error::LsarResult;
 
 #[tauri::command]
 pub fn get_player_paths() -> LsarResult<Vec<PathBuf>> {
-    let commands = ["mpv"];
+    let commands = if cfg!(target_os = "windows") {
+        ["mpv.exe"]
+    } else {
+        ["mpv"]
+    };
     debug!("Searching for player commands: {:?}", commands);
 
     let mut player_paths = Vec::new();
@@ -14,9 +18,13 @@ pub fn get_player_paths() -> LsarResult<Vec<PathBuf>> {
         e
     })?;
 
-    debug!("PATH environment variable found");
+    debug!("PATH environment variable found: {}", paths);
 
-    for path_entry in paths.split(':') {
+    for path_entry in paths.split(if cfg!(target_os = "windows") {
+        ';'
+    } else {
+        ':'
+    }) {
         debug!("Searching in PATH entry: {}", path_entry);
         for cmd in &commands {
             let path = PathBuf::from(path_entry).join(cmd);

--- a/src/App.scss
+++ b/src/App.scss
@@ -12,6 +12,10 @@
   z-index: 99;
 }
 
+.alley-toast {
+  z-index: 10000;
+}
+
 #settings-button {
   position: fixed;
   right: 20px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,6 @@ const App = () => {
       </AppContext.Provider>
 
       <LazyToast
-        class="message"
         open={!!toast()}
         placement="bottom"
         alert={{

--- a/src/command.ts
+++ b/src/command.ts
@@ -46,5 +46,7 @@ export const insertHistory = async (history: HistoryItem) =>
 export const deleteHistoryByID = async (id: number) =>
   invoke<void>("delete_a_history_by_id", { id });
 
-export const eval_result = async (result: string) =>
+export const evalResult = async (result: string) =>
   invoke<void>("eval_result", { result });
+
+export const getPlayerPaths = async () => invoke<string[]>("get_player_paths");

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,6 +1,12 @@
 import { open } from "@tauri-apps/plugin-dialog";
-import { createEffect, createSignal, Show, useContext } from "solid-js";
-import { writeConfigFile } from "~/command";
+import {
+  createEffect,
+  createSignal,
+  onMount,
+  Show,
+  useContext,
+} from "solid-js";
+import { getPlayerPaths, writeConfigFile } from "~/command";
 import { AppContext } from "~/context";
 import {
   LazyButton,
@@ -15,7 +21,7 @@ import {
 const Settings = () => {
   const [
     _,
-    __,
+    { setToast },
     { config: defaultConfig, refetchConfig },
     ___,
     { showSettings, setShowSettings },
@@ -24,6 +30,27 @@ const Settings = () => {
   const [lsarConfig, setLsarConfig] = createSignal(defaultConfig());
 
   createEffect(() => setLsarConfig(defaultConfig()));
+
+  onMount(async () => {
+    if (defaultConfig()?.player.path) return;
+
+    const paths = await getPlayerPaths();
+    if (!paths.length) return;
+
+    setLsarConfig(
+      (prev) =>
+        prev && {
+          ...prev,
+          player: { path: paths[0], args: [] },
+        },
+    );
+
+    setToast({
+      type: "success",
+      message:
+        "已自动选择播放器，如果此播放器不是你想使用的播放器，请点击“重新选择”按钮自行选择",
+    });
+  });
 
   const close = () => setShowSettings(false);
 
@@ -66,7 +93,7 @@ const Settings = () => {
   return (
     <LazyDialog
       show={showSettings() || !defaultConfig()?.player.path}
-      onClose={() => {}}
+      onClose={() => { }}
       maskClosable={false}
     >
       <LazyFlex direction="vertical" gap={8} style={{ "min-width": "400px" }}>

--- a/src/parser/douyu/index.ts
+++ b/src/parser/douyu/index.ts
@@ -1,4 +1,4 @@
-import { eval_result } from "~/command";
+import { evalResult } from "~/command";
 import LiveStreamParser from "../base";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
@@ -15,8 +15,8 @@ class DouyuParser extends LiveStreamParser {
 
   async parse(): Promise<ParsedResult | Error> {
     const unlisten = await listen<string>("JS-EVAL", async (e) => {
-      const evalResult = eval(e.payload);
-      await eval_result(evalResult);
+      const result = eval(e.payload);
+      await evalResult(result);
     });
 
     try {


### PR DESCRIPTION
- 修正了 `get_player_paths` 命令中的播放器路径处理，使其在 Windows 上使用 `.exe` 扩展名，并使用正确的路径分隔符。
- 在 `App.scss` 中新增了 `.alley-toast` 类以提高 Toast 消息的层级，确保其显示在 dialog 之上。
- 在 `settings/index.tsx` 中添加了播放器路径自动检测逻辑，并在首次加载设置时显示成功消息。