### PR TITLE
修改条件编译配置，仅在桌面环境且非调试模式下启用更新模块

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ mod parser;
 mod path;
 mod platform;
 mod setup;
-#[cfg(desktop)]
+#[cfg(all(desktop, not(debug_assertions)))]
 mod update;
 mod utils;
 

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -51,8 +51,8 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         app.package_info().version
     );
 
-    #[cfg(desktop)]
-    setup_desktop_features(app)?;
+    #[cfg(all(desktop, not(debug_assertions)))]
+    setup_updater(app)?;
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     apply_window_effect(app)?;
@@ -68,8 +68,8 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-#[cfg(desktop)]
-fn setup_desktop_features(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+#[cfg(all(desktop, not(debug_assertions)))]
+fn setup_updater(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     info!("Initializing update plugin");
     app.handle()
         .plugin(tauri_plugin_updater::Builder::new().build())?;


### PR DESCRIPTION
- 将更新模块的条件编译从仅在桌面环境下启用改为在非调试模式下的桌面环境启用。
- 对应地修改了 setup.rs 中对 setup_desktop_features 的调用，并将其重命名为 setup_updater 以更准确反映其功能。