### PR TITLE
fix: #114

### DIFF
--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -2,7 +2,7 @@ export const INVALID_INPUT = Error("无法从链接中获取房间号");
 export const WRONG_SECOND_LEVEL_DOMAIN = Error("域名不匹配");
 
 export const getSecondLevelDomain = (url: string) => {
-  const domainPart = url.split("://")[1];
+  const domainPart = url.split("?")[0].split("://")[1];
 
   const domainParts = domainPart.split(".");
 


### PR DESCRIPTION
修复从URL中获取二级域名时忽略查询字符串的问题。

在`getSecondLevelDomain`函数中，现在我们在分割URL以获取域名部分之前会先移除查询字符串（如果存在的话）。这样可以确保即使URL包含查询参数，也能正确地提取出二级域名。

- 在分割协议（`://`）之前先通过`split('?')[0]`移除了可能存在的查询字符串。
- 这样做的目的是为了防止查询字符串影响到后续对域名部分的处理。