### PR TITLE
refactor(parser): 重构 HTTP 客户端的 POST 方法

### DIFF
--- a/src-tauri/src/parser/http_client.rs
+++ b/src-tauri/src/parser/http_client.rs
@@ -113,13 +113,17 @@ impl HttpClient {
         Ok(json)
     }
 
-    pub async fn post<T: DeserializeOwned>(&self, url: &str, body: &str) -> LsarResult<T> {
+    pub async fn post<D: DeserializeOwned, T: Serialize + ?Sized>(
+        &self,
+        url: &str,
+        form: &T,
+    ) -> LsarResult<D> {
         info!("Sending POST request with body to: {}", url);
         let response = self
             .send_request(
                 self.inner
                     .post(url)
-                    .body(body.to_string())
+                    .form(form)
                     .header(CONTENT_TYPE, "application/x-www-form-urlencoded"),
             )
             .await?;


### PR DESCRIPTION
- 修改 post 方法使其支持泛型序列化和反序列化
- 使用 form 方法替代 body 方法发送表单数据
- 更新方法签名以提高灵活性和可读性