### PR TITLE
build: 更新 mirror-latest-json 脚本中的 GitHub 镜像列表

### DIFF
--- a/.scripts/mirror-latest-json.js
+++ b/.scripts/mirror-latest-json.js
@@ -2,8 +2,9 @@ import fs from "fs";
 import path from "path";
 
 const mirrors = [
-  { host: "mirror.ghproxy.com", prefix: true },
-  { host: "kkgithub.com" },
+  { host: "gh-proxy.com", prefix: true },
+  { host: "ghproxy.cfd", prefix: true },
+  { host: "ghproxy.net", prefix: true },
 ];
 
 const GITHUB = "https://github.com/";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,7 @@
       "endpoints": [
         "https://app.thepoy.cc/lsar/latest-mirror-1.json",
         "https://app.thepoy.cc/lsar/latest-mirror-2.json",
+        "https://app.thepoy.cc/lsar/latest-mirror-3.json",
         "https://github.com/alley-rs/lsar/releases/latest/download/latest.json"
       ]
     }


### PR DESCRIPTION
- 将 "mirror.ghproxy.com" 替换为 "gh-proxy.com"
- 新增 "ghproxy.cfd" 和 "ghproxy.net" 镜像
- 为新镜像添加 prefix 属性以保持与旧镜像相同的配置