### PR TITLE
refactor(title-bar): 将scss样式迁移至vanilla-extract

### DIFF
--- a/src/components/title-bar/index.css.ts
+++ b/src/components/title-bar/index.css.ts
@@ -1,0 +1,10 @@
+import { style } from "@vanilla-extract/css";
+
+export const titlebar = style({
+  height: "28px", // 与 macOS 标题栏高度一致
+  width: "100%",
+  backgroundColor: "transparent",
+  top: 0,
+  left: 0,
+  zIndex: 9999,
+});

--- a/src/components/title-bar/index.scss
+++ b/src/components/title-bar/index.scss
@@ -1,8 +1,0 @@
-.titlebar {
-  height: 28px;
-  width: 100vw;
-  background-color: transparent;
-  top: 0;
-  left: 0;
-  z-index: 9999;
-}

--- a/src/components/title-bar/index.tsx
+++ b/src/components/title-bar/index.tsx
@@ -1,5 +1,5 @@
-import "./index.scss";
+import { titlebar } from "./index.css";
 
-const TitleBar = () => <div data-tauri-drag-region class="titlebar" />;
+const TitleBar = () => <div data-tauri-drag-region class={titlebar} />;
 
 export default TitleBar;


### PR DESCRIPTION
迁移标题栏样式从scss到vanilla-extract以提升类型安全和维护性