### PR TITLE
feat: 更新 fluent-solid 依赖并添加主题样式

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@tauri-apps/plugin-shell": "^2.3.1",
     "@tauri-apps/plugin-updater": "2.9.0",
     "@vanilla-extract/css": "^1.17.4",
-    "fluent-solid": "^0.2.9",
+    "fluent-solid": "^0.2.10",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.9.9"
   },

--- a/src/index.css.ts
+++ b/src/index.css.ts
@@ -1,8 +1,40 @@
 import { globalStyle } from "@vanilla-extract/css";
-import { vars } from "fluent-solid/lib/themes";
+import {
+  darkTheme,
+  lightTheme,
+  themeContract,
+  vars,
+} from "fluent-solid/lib/themes";
 
 globalStyle(":root", {
   fontFamily: vars.fontFamilyBase,
+  color: themeContract.colorNeutralForeground1,
+  backgroundColor: themeContract.colorNeutralBackground1,
+});
+
+globalStyle('[data-theme="dark"]', {
+  vars: darkTheme,
+});
+globalStyle('[data-theme="light"]', {
+  vars: lightTheme,
+});
+
+globalStyle("::-webkit-scrollbar", {
+  width: "8px",
+  height: "8px",
+});
+
+globalStyle("::-webkit-scrollbar-track", {
+  backgroundColor: themeContract.colorTransparentBackground,
+});
+
+globalStyle("::-webkit-scrollbar-thumb", {
+  borderRadius: "4px",
+  backgroundColor: themeContract.colorNeutralStencil2Alpha,
+});
+
+globalStyle("::-webkit-scrollbar-thumb:hover", {
+  backgroundColor: themeContract.colorNeutralStencil1Alpha,
 });
 
 globalStyle("html, body", {


### PR DESCRIPTION
升级 fluent-solid 到 0.2.10 版本
添加深色和浅色主题支持
优化滚动条样式