### PR TITLE
ci(publish): 修改发布流程以支持手动触发版本更新

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,16 @@
-name: "publish"
+name: "Bump new version"
 on:
-  push:
-    branches:
-      - release
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   create-release:
@@ -11,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
-      package_version: ${{ env.PACKAGE_VERSION }}
+      package_version: ${{ env.VERSION }}
       latest_version: ${{ steps.latest-version.outputs.result }}
       changelog: ${{ steps.github_release_changelog.outputs.changelog }}
 
@@ -23,32 +31,26 @@ jobs:
         with:
           node-version: 20
 
-      - name: get version
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+      - name: Setup Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: check latest version
-        uses: actions/github-script@v7
-        id: latest-version
-        with:
-          script: |
-            const { data } = await github.request(
-              'GET /repos/{owner}/{repo}/releases/latest', 
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-              }
-            )
+      - name: Bump version
+        run: |
+          npm version ${{ github.event.inputs.bump_type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Bumping version to: $VERSION"
 
-            const latesVersion = data.tag_name.slice(1)
+      - name: Create and push release branch
+        run: |
+          git checkout -b release
+          git add package.json
+          git commit -m "Bump version to ${{ env.VERSION }}"
+          git push origin release --force
 
-            if (latesVersion === process.env.PACKAGE_VERSION) throw new Error("当前要发布的版本号与 latest 版本号相同")
-
-            return latesVersion
-
-      - name: build changelog
+      - name: Build changelog
         id: github_release_changelog
         uses: mikepenz/release-changelog-builder-action@v3
         with:
@@ -68,8 +70,8 @@ jobs:
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${process.env.PACKAGE_VERSION}`,
-              name: `v${process.env.PACKAGE_VERSION}`,
+              tag_name: `v${process.env.VERSION}`,
+              name: `v${process.env.VERSION}`,
               body: process.env.changelog,
               draft: true,
             })
@@ -132,7 +134,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-22.04
-    needs: [create-release, build-tauri]
+    needs: build-tauri
 
     steps:
       - name: publish release
@@ -150,11 +152,41 @@ jobs:
               draft: false,
             })
 
+  update-main-verison:
+    needs: publish-release
+    if: success()
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: update main version
+        run: |
+          git checkout main
+          git merge release --ff-only  # 或者使用 cherry-pick 获取版本更新的 commit
+          git push origin main
+
+  cleanup-release-branch:
+    needs: update-main-verison
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: success()
+    steps:
+      - name: Delete release branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/release'
+            })
+
   upload_mirror_json:
     permissions:
       contents: write
     runs-on: ubuntu-22.04
-    needs: [create-release, publish-release]
+    needs: publish-release
     env:
       release_id: ${{ needs.create-release.outputs.release_id }}
 


### PR DESCRIPTION
将发布流程从推送触发改为手动触发，支持选择版本更新类型（patch/minor/major）
自动创建发布分支并更新版本号，完成后合并到 main 分支并清理发布分支