### PR TITLE
ci(workflow): 将Node.js版本从固定值改为lts/*并移除npm缓存

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "npm"
+          node-version: lts/*
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -112,8 +111,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: "npm"
+          node-version: lts/*
 
       - name: Setup Git
         run: |
@@ -196,7 +194,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: "npm"
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -339,7 +336,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: Get latest.json
         id: get-latest


### PR DESCRIPTION
简化Node.js版本配置，使用LTS版本替代固定版本20
移除不再需要的npm缓存配置