### PR TITLE
ci(workflow): 添加必要的Ubuntu依赖以支持构建

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,11 @@ jobs:
           bun run check
           bun run build:vite
 
+      - name: Install necessary Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev
+
       - name: Run Rust checks
         working-directory: src-tauri
         run: |


### PR DESCRIPTION
在发布工作流中添加安装Ubuntu系统依赖的步骤，确保Rust项目构建所需的库可用