### PR TITLE
chore: 忽略 VSCode 配置文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 bun.lockb
 *.db
 .DS_Store
+.vscode


### PR DESCRIPTION
- 在 .gitignore 文件中添加 .vscode 目录，以忽略 VSCode 的配置文件