### PR TITLE
fix(douyin解析器): 将partition_road_map改为可选字段并处理空分区信息

### DIFF
--- a/src-tauri/src/parsers/douyin/mod.rs
+++ b/src-tauri/src/parsers/douyin/mod.rs
@@ -227,7 +227,10 @@ impl DouyinParser {
         debug!("Room status: {}", room_data.status);
 
         let stream_urls = self.extract_stream_urls(room_data)?;
-        let category = self.extract_category(partition_info);
+        let category = partition_info
+            .as_ref()
+            .map(|pi| self.extract_category(pi))
+            .unwrap_or_default();
 
         let result = ParsedResult {
             platform: Platform::Douyin,

--- a/src-tauri/src/parsers/douyin/models.rs
+++ b/src-tauri/src/parsers/douyin/models.rs
@@ -11,7 +11,7 @@ pub struct RoomInfo {
 pub struct RoomData {
     pub data: Vec<StreamData>,
     pub user: UserInfo,
-    pub partition_road_map: PartitionRoadMap,
+    pub partition_road_map: Option<PartitionRoadMap>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
处理抖音API返回可能缺少分区信息的情况，将RoomData中的partition_road_map改为Option类型 在提取分类信息时增加对空分区信息的处理，避免panic