### PR TITLE
ci(workflow): 优化 nightly 工作流版本号管理

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,40 +28,25 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
-      package_version: ${{ env.PACKAGE_VERSION }}
+      package_version: ${{ env.VERSION }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
 
-      - name: get version
-        run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-
-      - name: check latest version
-        uses: actions/github-script@v7
-        id: latest-version
-        with:
-          script: |
-            const { data } = await github.request(
-              'GET /repos/{owner}/{repo}/releases/latest', 
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-              }
-            )
-
-            const latesVersion = data.tag_name.slice(1)
-
-            if (latesVersion === process.env.PACKAGE_VERSION) throw new Error("当前要发布的版本号与 latest 版本号相同")
-
-            return latesVersion
+      # 使用 main 分支的包版本的 patch 作为 nightly 版本号
+      - name: Bump version
+        run: |
+          npm version ${{ github.event.inputs.bump_type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Bumping version to: $VERSION"
 
       - name: get old nightly release id
         run: |


### PR DESCRIPTION
使用 main 分支的包版本 patch 作为 nightly 版本号，简化版本获取逻辑并移除不必要的版本检查步骤