### PR TITLE
ci(workflow): 修改发布工作流以排除nightly标签外的已标记提交

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,16 @@ jobs:
       - name: Check if release is needed
         id: check
         run: |
-          # 检查是否有未发布的更改
+          # 检查是否有未发布的更改，但排除 nightly 标签
           if git describe --tags --exact-match HEAD 2>/dev/null; then
-            echo "Current commit is already tagged, skipping release"
-            echo "should_continue=false" >> $GITHUB_OUTPUT
+            current_tag=$(git describe --tags --exact-match HEAD 2>/dev/null)
+            if [[ "$current_tag" == "nightly" ]]; then
+              echo "Current commit has nightly tag, proceeding with release"
+              echo "should_continue=true" >> $GITHUB_OUTPUT
+            else
+              echo "Current commit is already tagged with $current_tag, skipping release"
+              echo "should_continue=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "should_continue=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
修改发布工作流的检查逻辑，当提交已被标记为非nightly标签时跳过发布，仅对nightly标签或未标记提交继续执行发布流程