### PR TITLE
ci(workflow): 更新夜间构建的触发条件

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,8 +137,8 @@ jobs:
             return data.id;
 
   build-nightly:
-    needs: [check-nightly-conditions, create-nightly-release]
-    if: needs.check-nightly-conditions.outputs.should_build == 'true'
+    needs: create-nightly-release
+    if: needs.create-nightly-release.outputs.result == 'success'
     permissions:
       contents: write
     strategy:
@@ -234,7 +234,7 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     needs: [check-nightly-conditions, create-nightly-release, build-nightly]
-    if: needs.check-nightly-conditions.outputs.should_build == 'true'
+    if: always() && needs.build-nightly.result == 'success'
 
     steps:
       - name: Publish nightly release


### PR DESCRIPTION
将夜间构建的触发条件从检查结果改为发布结果，确保只在发布成功时构建