### PR TITLE
ci(workflow): 修改 nightly 工作流的执行条件

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,7 +138,7 @@ jobs:
 
   build-nightly:
     needs: create-nightly-release
-    if: needs.create-nightly-release.outputs.result == 'success'
+    if: always() && needs.create-nightly-release.outputs.result == 'success'
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
将条件改为 always() && 以确保在 create-nightly-release 步骤成功后继续执行