### PR TITLE
ci(workflow): 调整 nightly 构建的定时任务为 UTC 时间

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@ name: "Nightly Build"
 
 on:
   schedule:
-    # 每天0点执行
-    - cron: '0 0 * * *'
+    # 每天UTC时间16点执行，即北京时间0点
+    - cron: '0 16 * * *'
   workflow_dispatch: # 允许手动触发
 
 env:


### PR DESCRIPTION
将 cron 表达式从UTF时间 0 点调整为 UTC 时间 16 点执行