### PR TITLE
feat(tauri): add log color feature for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tauri build",
     "serve": "vite preview",
     "tauri": "tauri",
-    "start:dev": "cross-env RUST_BACKTRACE=1 tauri dev",
+    "start:dev": "cross-env RUST_BACKTRACE=1 tauri dev --features log-color",
     "check": "biome check --write src",
     "dev": "bun run start:dev"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2540,6 +2540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5443,6 +5452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,6 +80,9 @@ windows = { version = "0.61", features = [
   "Win32_System_Threading",
 ] }
 
+[features]
+log-color = ["tracing-subscriber/ansi"]
+
 [profile.release]
 panic = "abort"
 codegen-units = 1


### PR DESCRIPTION
- Add `log-color` feature to `tauri` dev command
- Include `nu-ansi-term` dependency for colored logging
- Update `Cargo.toml` with new feature flag