### PR TITLE
refactor(parser): move platform-specific parsing logic to separate files

### DIFF
--- a/src/commands/parser/bigo.ts
+++ b/src/commands/parser/bigo.ts
@@ -1,0 +1,8 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const parseBigo = async (roomId: number) => {
+  const result = await invoke<ParsedResult>("parse_bigo", {
+    roomId,
+  });
+  return result;
+};

--- a/src/commands/parser/bili.ts
+++ b/src/commands/parser/bili.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const parseBilibili = async (
+  roomID: number,
+  cookie: string,
+  url: string
+) => {
+  const result = await invoke<ParsedResult>("parse_bilibili", {
+    roomId: roomID,
+    cookie: cookie,
+    url: url || null,
+  });
+  return result;
+};

--- a/src/commands/parser/douyin.ts
+++ b/src/commands/parser/douyin.ts
@@ -1,0 +1,8 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const parseDouyin = async (roomID: number) => {
+  const result = await invoke<ParsedResult>("parse_douyin", {
+    roomId: roomID,
+  });
+  return result;
+};

--- a/src/commands/parser/douyu.ts
+++ b/src/commands/parser/douyu.ts
@@ -1,0 +1,8 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const parseDouyu = async (roomID: number) => {
+  const result = await invoke<ParsedResult>("parse_douyu", {
+    roomId: roomID,
+  });
+  return result;
+};

--- a/src/commands/parser/huya.ts
+++ b/src/commands/parser/huya.ts
@@ -1,0 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const parseHuya = async (roomID: number, url: string) => {
+  const result = await invoke<ParsedResult>("parse_huya", {
+    roomId: roomID || null,
+    url: url,
+  });
+  return result;
+};

--- a/src/commands/parser/index.ts
+++ b/src/commands/parser/index.ts
@@ -1,0 +1,5 @@
+export { parseBigo } from "./bigo";
+export { parseBilibili } from "./bili";
+export { parseDouyin } from "./douyin";
+export { parseDouyu } from "./douyu";
+export { parseHuya } from "./huya";

--- a/src/parser/bigo/index.ts
+++ b/src/parser/bigo/index.ts
@@ -1,6 +1,8 @@
+import { parseBigo } from "~/commands/parser";
+
 import LiveStreamParser from "../base";
+
 import { parseRoomID } from "../utils";
-import { invoke } from "@tauri-apps/api/core";
 
 class BigoParser extends LiveStreamParser {
   constructor(roomID: number) {
@@ -9,9 +11,7 @@ class BigoParser extends LiveStreamParser {
 
   async parse(): Promise<ParsedResult | Error> {
     try {
-      const result = await invoke<ParsedResult>("parse_bigo", {
-        roomId: this.roomID,
-      });
+      const result = await parseBigo(this.roomID);
       return result;
     } catch (e) {
       return Error(String(e));

--- a/src/parser/bilibili/index.ts
+++ b/src/parser/bilibili/index.ts
@@ -1,5 +1,6 @@
+import { parseBilibili } from "~/commands/parser";
+
 import LiveStreamParser from "../base";
-import { invoke } from "@tauri-apps/api/core";
 
 class BilibiliParser extends LiveStreamParser {
   cookie: string;
@@ -12,11 +13,7 @@ class BilibiliParser extends LiveStreamParser {
 
   async parse(): Promise<ParsedResult | Error> {
     try {
-      const result = await invoke<ParsedResult>("parse_bilibili", {
-        roomId: this.roomID,
-        cookie: this.cookie,
-        url: this.url || null,
-      });
+      const result = await parseBilibili(this.roomID, this.cookie, this.url);
       return result;
     } catch (e) {
       return Error(String(e));
@@ -26,7 +23,7 @@ class BilibiliParser extends LiveStreamParser {
 
 export default function createBilibiliParser(
   input: string | number,
-  cookie: string,
+  cookie: string
 ) {
   let roomID: number | undefined;
   let url: string | undefined;

--- a/src/parser/douyin/index.ts
+++ b/src/parser/douyin/index.ts
@@ -1,6 +1,8 @@
+import { parseDouyin } from "~/commands/parser";
+
 import LiveStreamParser from "../base";
+
 import { parseRoomID } from "../utils";
-import { invoke } from "@tauri-apps/api/core";
 
 class DouyinParser extends LiveStreamParser {
   constructor(roomID: number) {
@@ -9,9 +11,7 @@ class DouyinParser extends LiveStreamParser {
 
   async parse(): Promise<ParsedResult | Error> {
     try {
-      const result = await invoke<ParsedResult>("parse_douyin", {
-        roomId: this.roomID,
-      });
+      const result = await parseDouyin(this.roomID);
       return result;
     } catch (e) {
       return Error(String(e));

--- a/src/parser/douyu/index.ts
+++ b/src/parser/douyu/index.ts
@@ -1,7 +1,10 @@
-import { evalResult } from "~/command";
-import LiveStreamParser from "../base";
 import { listen } from "@tauri-apps/api/event";
-import { invoke } from "@tauri-apps/api/core";
+
+import { evalResult } from "~/command";
+import { parseDouyu } from "~/commands/parser";
+
+import LiveStreamParser from "../base";
+
 import {
   INVALID_INPUT,
   parseRoomID,
@@ -20,9 +23,7 @@ class DouyuParser extends LiveStreamParser {
     });
 
     try {
-      const result = await invoke<ParsedResult>("parse_douyu", {
-        roomId: this.roomID,
-      });
+      const result = await parseDouyu(this.roomID);
       return result;
     } catch (e) {
       return Error(String(e));
@@ -33,7 +34,7 @@ class DouyuParser extends LiveStreamParser {
 }
 
 export default function createDouyuParser(
-  input: string | number,
+  input: string | number
 ): DouyuParser | Error {
   let roomID = parseRoomID(input);
   // 斗鱼的房间号可能在查询参数 rid 中

--- a/src/parser/huya/index.ts
+++ b/src/parser/huya/index.ts
@@ -1,5 +1,6 @@
+import { parseHuya } from "~/commands/parser";
+
 import LiveStreamParser from "../base";
-import { invoke } from "@tauri-apps/api/core";
 
 class HuyaParser extends LiveStreamParser {
   baseURL = "https://m.huya.com/";
@@ -12,10 +13,7 @@ class HuyaParser extends LiveStreamParser {
 
   async parse(): Promise<ParsedResult | Error> {
     try {
-      const result = await invoke<ParsedResult>("parse_huya", {
-        roomId: this.roomID || null,
-        url: this.url,
-      });
+      const result = await parseHuya(this.roomID, this.url);
       return result;
     } catch (error) {
       return error instanceof Error ? error : new Error(String(error));
@@ -24,7 +22,7 @@ class HuyaParser extends LiveStreamParser {
 }
 
 export default function createHuyaParser(
-  input: string | number,
+  input: string | number
 ): HuyaParser | Error {
   let roomID: number | undefined;
   let url: string | undefined;


### PR DESCRIPTION
- Create new files for Bigo, Bilibili, Douyin, Douyu, and Huya parsing logic
- Move platform-specific parsing functions to new files in src/commands/parser/
- Update parser classes to use new parsing functions instead of direct invoke calls
- Remove redundant import of invoke in parser classes
- Simplify parser class structure and improve code readability