### PR TITLE
refactor(ui): 替换部分组件中的 API 图标为闪电图标

### DIFF
--- a/src/components/history/Item/index.tsx
+++ b/src/components/history/Item/index.tsx
@@ -1,5 +1,7 @@
 import { createMemo, Show } from "solid-js";
-import { AiFillApi, AiFillChrome, AiFillDelete } from "solid-icons/ai";
+
+import { AiFillChrome, AiFillDelete } from "solid-icons/ai";
+import { TiFlash } from "solid-icons/ti";
 
 import { deleteHistoryByID, open } from "~/command";
 import {
@@ -80,7 +82,7 @@ const HistoryItem = (props: HistoryItemProps) => {
                   when={!isParsing()}
                   fallback={<LazySpinner size="extra-tiny" />}
                 >
-                  <AiFillApi font-size={BUTTON_ICON_FONT_SIZE} />
+                  <TiFlash font-size={BUTTON_ICON_FONT_SIZE} />
                 </Show>
               }
               appearance="transparent"

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show } from "solid-js";
-import { AiFillApi } from "solid-icons/ai";
+
+import { TiFlash } from "solid-icons/ti";
 
 import { LazyButton, LazyInput, LazyBadge, LazySpinner } from "~/lazy";
 
@@ -97,7 +98,7 @@ const Search = () => {
                 when={!isSearchParsing()}
                 fallback={<LazySpinner size="extra-tiny" />}
               >
-                <AiFillApi />
+                <TiFlash />
               </Show>
             }
             isLoading={isSearchParsing()}


### PR DESCRIPTION
- 在 history/Item 组件中，用 TiFlash 替换 AiFillApi 图标
- 在 search 组件中，用 TiFlash 替换 AiFillApi 图标
- 删除了对 AiFillApi 图标的导入，新增 TiFlash 图标导入
- 保持图标样式和加载状态表现一致