### PR TITLE
fix(parsers): correct variable name in bigo parser function

### DIFF
--- a/src-tauri/src/parsers/bigo/mod.rs
+++ b/src-tauri/src/parsers/bigo/mod.rs
@@ -64,6 +64,6 @@ impl Parser for BigoParser {
 
 #[tauri::command]
 pub async fn parse_bigo(room_id: u64) -> LsarResult<ParsedResult> {
-    let mut douyu = BigoParser::new(room_id);
-    douyu.parse().await
+    let mut bigo = BigoParser::new(room_id);
+    bigo.parse().await
 }


### PR DESCRIPTION
- Rename variable from `douyu` to `bigo` in `parse_bigo` function
- Ensure variable name matches the parser context for clarity
- Maintain asynchronous parsing call functionality