### PR TITLE
fix: 将 Linux 平台下未实现的缓存大小计算改为返回明确错误

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -38,7 +38,11 @@ pub fn calc_cache_size() -> LsarResult<String> {
             "com.alley.lsar/EBWebView"
         } else {
             // FIXME: Linux 没有测试条件，暂不支持
-            unimplemented!()
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "unsupported platform",
+            )
+            .into());
         });
 
     let total = Arc::new(AtomicU64::new(0));


### PR DESCRIPTION
fix: #289